### PR TITLE
Permission check for non-page models

### DIFF
--- a/glitter/admin.py
+++ b/glitter/admin.py
@@ -128,7 +128,9 @@ class GlitterAdminMixin(object):
 
     def has_edit_permission(self, request, obj=None, version=None):
         # Has the edit permission for this object type
-        can_edit = request.user.has_perm(self.opts.app_label + '.' + 'edit_page')
+        can_edit = request.user.has_perm('{}.edit_{}'.format(
+            self.opts.app_label, self.opts.model_name
+        ))
 
         if can_edit and version is not None:
             # Version must not be saved, and must belong to this user
@@ -138,7 +140,9 @@ class GlitterAdminMixin(object):
         return can_edit
 
     def has_publish_permission(self, request, obj=None):
-        return request.user.has_perm(self.opts.app_label + '.' + 'publish_page')
+        return request.user.has_perm('{}.publish_{}'.format(
+            self.opts.app_label, self.opts.model_name
+        ))
 
     def response_add(self, request, obj, *args, **kwargs):
         if '_saveandedit' in request.POST:

--- a/glitter/tests/sample/models.py
+++ b/glitter/tests/sample/models.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
+
+from glitter.mixins import GlitterMixin
+
+
+@python_2_unicode_compatible
+class Book(GlitterMixin):
+    title = models.CharField(max_length=100)
+
+    def __str__(self):
+        return self.title

--- a/glitter/tests/test_admin.py
+++ b/glitter/tests/test_admin.py
@@ -182,8 +182,10 @@ class TestPermissions(TestCase):
         # Page with an unsaved page version
         self.page = Page.objects.create(url='/test/', title='Test page')
         self.page_version = Version.objects.create(
-            content_type=ContentType.objects.get_for_model(Page), object_id=self.page.id,
-            template_name='glitter/sample.html', owner=self.editor
+            content_type=ContentType.objects.get_for_model(Page),
+            object_id=self.page.id,
+            template_name='glitter/sample.html',
+            owner=self.editor,
         )
         self.page_admin = PageAdmin(Page, AdminSite())
 
@@ -197,6 +199,7 @@ class TestPermissions(TestCase):
 
         request.user = self.editor
         self.assertTrue(self.page_admin.has_edit_permission(request=request))
+
         request.user = self.staff
         self.assertFalse(self.page_admin.has_edit_permission(request=request))
 
@@ -208,6 +211,7 @@ class TestPermissions(TestCase):
         self.assertFalse(self.page_admin.has_edit_permission(
             request=request, version=self.page_version
         ))
+
         request.user = self.editor
         self.assertTrue(self.page_admin.has_edit_permission(
             request=request, version=self.page_version
@@ -219,6 +223,7 @@ class TestPermissions(TestCase):
 
         request.user = self.publisher
         self.assertTrue(self.page_admin.has_publish_permission(request=request))
+
         request.user = self.staff
         self.assertFalse(self.page_admin.has_publish_permission(request=request))
 
@@ -228,8 +233,10 @@ class TestPermissions(TestCase):
 
         request.user = self.editor
         self.assertTrue(self.book_admin.has_edit_permission(request=request))
+
         request.user = self.publisher
         self.assertTrue(self.book_admin.has_publish_permission(request=request))
+
         request.user = self.staff
         self.assertFalse(self.book_admin.has_edit_permission(request=request))
         self.assertFalse(self.book_admin.has_publish_permission(request=request))

--- a/glitter/tests/test_admin.py
+++ b/glitter/tests/test_admin.py
@@ -19,6 +19,7 @@ from glitter.blocks.html.models import HTML
 from glitter.models import Version, ContentBlock
 from glitter.pages.admin import PageAdmin
 from glitter.pages.models import Page
+from glitter.tests.sample.models import Book
 
 
 SAMPLE_BLOCK_MISSING = 'glitter.tests.sampleblocks' not in settings.INSTALLED_APPS
@@ -132,13 +133,25 @@ class TestAdmin(TestCase):
         )
 
 
+@modify_settings(
+    INSTALLED_APPS={
+        'append': 'glitter.tests.sample',
+    },
+)
 class TestPermissions(TestCase):
     def setUp(self):
-        self.edit_permission = Permission.objects.get_by_natural_key(
+        # Permissions for objects we're testing
+        self.edit_page = Permission.objects.get_by_natural_key(
             'edit_page', 'glitter_pages', 'page'
         )
-        self.publish_permission = Permission.objects.get_by_natural_key(
+        self.publish_page = Permission.objects.get_by_natural_key(
             'publish_page', 'glitter_pages', 'page'
+        )
+        self.edit_book = Permission.objects.get_by_natural_key(
+            'edit_book', 'sample', 'book'
+        )
+        self.publish_book = Permission.objects.get_by_natural_key(
+            'publish_book', 'sample', 'book'
         )
 
         # Superuser
@@ -151,13 +164,15 @@ class TestPermissions(TestCase):
         self.editor = User.objects.create_user(username='editor', email='', password=None)
         self.editor.is_staff = True
         self.editor.save()
-        self.editor.user_permissions.add(self.edit_permission)
+        self.editor.user_permissions.add(self.edit_page, self.edit_book)
 
         # Publisher with edit and publish permissions
         self.publisher = User.objects.create_user(username='publisher', email='', password=None)
         self.publisher.is_staff = True
         self.publisher.save()
-        self.publisher.user_permissions.add(self.edit_permission, self.publish_permission)
+        self.publisher.user_permissions.add(
+            self.edit_page, self.publish_page, self.edit_book, self.publish_book
+        )
 
         # Staff with no editing permissions
         self.staff = User.objects.create_user(username='staff', email='', password=None)
@@ -171,6 +186,10 @@ class TestPermissions(TestCase):
             template_name='glitter/sample.html', owner=self.editor
         )
         self.page_admin = PageAdmin(Page, AdminSite())
+
+        # Sample model
+        self.book = Book.objects.create(title='Hello')
+        self.book_admin = PageAdmin(Book, AdminSite())
 
     def test_edit_permission(self):
         # Only people with glitter_pages.edit_page have edit permission
@@ -202,6 +221,18 @@ class TestPermissions(TestCase):
         self.assertTrue(self.page_admin.has_publish_permission(request=request))
         request.user = self.staff
         self.assertFalse(self.page_admin.has_publish_permission(request=request))
+
+    def test_book_model(self):
+        # Test that permissions work with different types of models
+        request = HttpRequest()
+
+        request.user = self.editor
+        self.assertTrue(self.book_admin.has_edit_permission(request=request))
+        request.user = self.publisher
+        self.assertTrue(self.book_admin.has_publish_permission(request=request))
+        request.user = self.staff
+        self.assertFalse(self.book_admin.has_edit_permission(request=request))
+        self.assertFalse(self.book_admin.has_publish_permission(request=request))
 
 
 class BaseViewsCase(TestAdmin):

--- a/glitter/tests/test_admin.py
+++ b/glitter/tests/test_admin.py
@@ -9,6 +9,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
+from django.http import HttpRequest
 from django.test import TestCase, Client
 from django.test import override_settings, modify_settings
 from django.test.client import RequestFactory
@@ -129,6 +130,78 @@ class TestAdmin(TestCase):
             self.page_admin.get_fields(request),
             ['url', 'title', 'parent', 'login_required', 'show_in_navigation']
         )
+
+
+class TestPermissions(TestCase):
+    def setUp(self):
+        self.edit_permission = Permission.objects.get_by_natural_key(
+            'edit_page', 'glitter_pages', 'page'
+        )
+        self.publish_permission = Permission.objects.get_by_natural_key(
+            'publish_page', 'glitter_pages', 'page'
+        )
+
+        # Superuser
+        User = get_user_model()
+        self.superuser = User.objects.create_superuser(
+            username='superuser', email='', password=None
+        )
+
+        # Editor with editing permissions
+        self.editor = User.objects.create_user(username='editor', email='', password=None)
+        self.editor.is_staff = True
+        self.editor.save()
+        self.editor.user_permissions.add(self.edit_permission)
+
+        # Publisher with edit and publish permissions
+        self.publisher = User.objects.create_user(username='publisher', email='', password=None)
+        self.publisher.is_staff = True
+        self.publisher.save()
+        self.publisher.user_permissions.add(self.edit_permission, self.publish_permission)
+
+        # Staff with no editing permissions
+        self.staff = User.objects.create_user(username='staff', email='', password=None)
+        self.staff.is_staff = True
+        self.staff.save()
+
+        # Page with an unsaved page version
+        self.page = Page.objects.create(url='/test/', title='Test page')
+        self.page_version = Version.objects.create(
+            content_type=ContentType.objects.get_for_model(Page), object_id=self.page.id,
+            template_name='glitter/sample.html', owner=self.editor
+        )
+        self.page_admin = PageAdmin(Page, AdminSite())
+
+    def test_edit_permission(self):
+        # Only people with glitter_pages.edit_page have edit permission
+        request = HttpRequest()
+
+        request.user = self.editor
+        self.assertTrue(self.page_admin.has_edit_permission(request=request))
+        request.user = self.staff
+        self.assertFalse(self.page_admin.has_edit_permission(request=request))
+
+    def test_edit_version(self):
+        # Only the creator of an unsaved version can edit it
+        request = HttpRequest()
+
+        request.user = self.superuser
+        self.assertFalse(self.page_admin.has_edit_permission(
+            request=request, version=self.page_version
+        ))
+        request.user = self.editor
+        self.assertTrue(self.page_admin.has_edit_permission(
+            request=request, version=self.page_version
+        ))
+
+    def test_publish_permission(self):
+        # Only people with glitter_pages.publish_page have publish permission
+        request = HttpRequest()
+
+        request.user = self.publisher
+        self.assertTrue(self.page_admin.has_publish_permission(request=request))
+        request.user = self.staff
+        self.assertFalse(self.page_admin.has_publish_permission(request=request))
 
 
 class BaseViewsCase(TestAdmin):


### PR DESCRIPTION
We hardcoded `edit_page` and `publish_page` - this should fix that!

Closes #53.