### PR TITLE
Add block now immediately loads a popup window

### DIFF
--- a/glitter/blockadmin/blocks.py
+++ b/glitter/blockadmin/blocks.py
@@ -192,7 +192,7 @@ class BlockAdmin(ModelAdmin):
         # As this is the Django admin and we can't just set self.version_id due to thread safety
         # issues, we need to find the version ID of the page when adding a new block. It'll be
         # accessible in the URL - although this is a very hacky way to access it.
-        _, _, kwargs = resolve(request.path)
+        func, args, kwargs = resolve(request.path)
         version_id = kwargs.get('version_id', None)
 
         if version_id is None:

--- a/glitter/static/glitter/js/glitter_editor.js
+++ b/glitter/static/glitter/js/glitter_editor.js
@@ -52,15 +52,10 @@ GlitterEditor.jQuery = jQuery.noConflict(true);
     // Get the local namespaced utils
     var $ = GlitterEditor.jQuery;
 
-    var csrf_token,
-        add_block_url;
+    var csrf_token;
 
     GlitterEditor.store_csrf_token = function(token) {
         csrf_token = token;
-    };
-
-    GlitterEditor.set_add_block_url = function(url) {
-        add_block_url = url;
     };
 
 
@@ -177,56 +172,29 @@ GlitterEditor.jQuery = jQuery.noConflict(true);
             }
         });
 
-
-        var add_block_click = function(block_type) {
-            var column_name = $(this).parents(".glitter-column").data("columnName"),
-                block_top = $(this).parents(".glitter-button-row").data("blockTop");
-
-            $.ajax(add_block_url, {
-                type: "POST",
-                data: {
-                    csrfmiddlewaretoken: csrf_token,
-                    column: column_name,
-                    block_type: block_type,
-                    top: block_top
-                },
-                dataType: "json",
-                success: function(data) {
-                    if (data.column === undefined) {
-                        // If no column is returned, user probably tried to move a block too far
-                        return;
-                    }
-
-                    GlitterEditor.update_column(data.column, data.content);
-                }
-            });
+        var iframe_popup = function(url) {
+            $(document.body).addClass("glitter-lightbox-active").append('<div id="glitter-lightbox" class="glitter-lightbox"><iframe class="glitter-lightbox-iframe" src="' + url  + '" allowTransparency="true"></iframe></div>');
         };
 
         $(document).on("click", ".glitter-add-block", function() {
-            var block_type = $(this).data("blockType");
+            var iframe_url = $(this).data("popupUrl");
 
             // Avoid span with the same class
-            if (block_type === undefined) {
+            if (iframe_url === undefined) {
                 return;
             }
 
-            add_block_click.call(this, block_type);
+            iframe_popup(iframe_url);
         });
 
         $(document).on("change", ".glitter-add-block-select", function() {
-            var block_type = $(this).val();
-
-            add_block_click.call(this, block_type);
+            var iframe_url = $(this).val();
+            iframe_popup(iframe_url);
         });
 
         $(document).on("click", "#glitter-discard-version, .glitter-delete-block, .glitter-edit-block", function() {
-
             var iframe_url = $(this).data("popupUrl");
-
-            if (iframe_url){
-                $(document.body).addClass("glitter-lightbox-active").append('<div id="glitter-lightbox" class="glitter-lightbox"><iframe class="glitter-lightbox-iframe" src="' + iframe_url  + '" allowTransparency="true"></iframe></div>');
-            }
-
+            iframe_popup(iframe_url);
         });
 
         $(document).on("change", ".glitter-move-block-select", function() {
@@ -272,25 +240,6 @@ GlitterEditor.jQuery = jQuery.noConflict(true);
                     GlitterEditor.update_column(data.dest_column, data.dest_content);
                 }
             });
-        });
-
-        $(document).on('click', '.glitter-delete-block-ajax', function(e){
-          e.preventDefault();
-          var ajax_url = $(this).attr('data-ajax-url');
-
-          // Delete element.
-          var block_header = $(this).closest('.block-header');
-          block_header.next('.glitter_page_block').remove();
-          block_header.remove();
-
-          $.ajax(ajax_url, {
-              type: "POST",
-              data: {
-                  csrfmiddlewaretoken: csrf_token,
-                  delete: true,
-              },
-              dataType: "json",
-          });
         });
 
 

--- a/glitter/templates/glitter/include/column_edit.html
+++ b/glitter/templates/glitter/include/column_edit.html
@@ -1,15 +1,15 @@
 {% load admin_urls %}
 
-<!--[if !IE]><!--><div id="glitter_column_{{ column_slug }}" class="glitter-column" data-column-name="{{ column_name|escape }}"><!--<![endif]-->
-<!--[if IE]><div id="glitter_column_{{ column_slug }}" class="glitter-column glitter-column-ie" data-column-name="{{ column_name|escape }}"><![endif]-->
+<!--[if !IE]><!--><div id="glitter_column_{{ column_slug }}" class="glitter-column"><!--<![endif]-->
+<!--[if IE]><div id="glitter_column_{{ column_slug }}" class="glitter-column glitter-column-ie"><![endif]-->
     <div class="glitter-toolbar glitter-column-header">
-        <div class="glitter-button-row" data-block-top="true">
+        <div class="glitter-button-row">
             <span class="glitter-title">{{ verbose_name }}</span>
-            {% for block_model, block_title in default_blocks %}
-                <button class="glitter-button glitter-add-block glitter-{{ block_title|slugify }}" data-block-type="{{ block_model }}">Add {{ block_title }} Block</button>
+            {% for block_url, block_title in default_blocks_top %}
+                <button class="glitter-button glitter-add-block glitter-{{ block_title|slugify }}" data-popup-url="{{ block_url }}">Add {{ block_title }} Block</button>
             {% endfor %}
             <span class="glitter-button glitter-add-block glitter-add">
-                {{ add_block_widget }}
+                {{ add_block_widget_top }}
             </span>
         </div>
     </div>
@@ -17,13 +17,7 @@
     {% for block in blocks %}
         <div class="glitter-toolbar block-header">
             <div class="glitter-button-row">
-
-              {% if block.content_block.object_id %}
                 <button class="glitter-button glitter-primary-action glitter-delete-block" data-popup-url="{% url glitter.opts|admin_urlname:'block_delete' contentblock_id=block.content_block.id %}">Delete Block</button>
-              {% else %}
-                <a class="glitter-button glitter-primary-action glitter-delete-block glitter-delete-block-ajax" data-ajax-url="{% url glitter.opts|admin_urlname:'block_delete' contentblock_id=block.content_block.id %}">Delete Block</a>
-              {% endif %}
-
                 <button class="glitter-button glitter-primary-action glitter-edit-block" data-popup-url="{{ block.edit_url }}">Edit Block</button>
                 <span class="glitter-button glitter-primary-action glitter-move-block" data-move-url="{% url glitter.opts|admin_urlname:'block_move' contentblock_id=block.content_block.id %}">
                     {{ block.move_block_widget }}
@@ -41,11 +35,11 @@
         <div class="glitter-toolbar glitter-column-footer">
             <div class="glitter-button-row">
                 <span class="glitter-title">{{ verbose_name }}</span>
-                {% for block_model, block_title in default_blocks %}
-                    <button class="glitter-button glitter-add-block glitter-{{ block_title|slugify }}" data-block-type="{{ block_model }}">Add {{ block_title }} Block</button>
+                {% for block_url, block_title in default_blocks_bottom %}
+                    <button class="glitter-button glitter-add-block glitter-{{ block_title|slugify }}" data-popup-url="{{ block_url }}">Add {{ block_title }} Block</button>
                 {% endfor %}
                 <span class="glitter-button glitter-add-block glitter-add">
-                    {{ add_block_widget }}
+                    {{ add_block_widget_bottom }}
                 </span>
             </div>
         </div>

--- a/glitter/templates/glitter/include/head.html
+++ b/glitter/templates/glitter/include/head.html
@@ -7,8 +7,4 @@
 <script src="{% static 'glitter/js/glitter_editor.js' %}"></script>
 <script type="text/javascript">
     GlitterEditor.store_csrf_token("{{ csrf_token }}");
-
-    {% if edit_mode %}
-        GlitterEditor.set_add_block_url("{% url glitter.opts|admin_urlname:'block_add' version_id=glitter.version.id %}");
-    {% endif %}
 </script>

--- a/glitter/tests/test_admin.py
+++ b/glitter/tests/test_admin.py
@@ -353,7 +353,10 @@ class TestPageBlockAddView(BaseViewsCase):
     def setUp(self):
         super(TestPageBlockAddView, self).setUp()
         self.page_block_add_view_url = reverse(
-            'admin:%s_%s_block_add' % self.info, args=(self.page_version.id,)
+            'block_admin:%s_%s_add' % (HTML._meta.app_label, HTML._meta.model_name),
+            kwargs={
+                'version_id': self.page_version.id,
+            }
         )
 
     def test_permissions(self):

--- a/glitter/tests/test_admin.py
+++ b/glitter/tests/test_admin.py
@@ -13,7 +13,6 @@ from django.http import HttpRequest
 from django.test import TestCase, Client
 from django.test import override_settings, modify_settings
 from django.test.client import RequestFactory
-from django.utils.http import urlencode
 
 from glitter.forms import MoveBlockForm
 from glitter.blocks.html.models import HTML

--- a/glitter/tests/test_admin.py
+++ b/glitter/tests/test_admin.py
@@ -352,12 +352,12 @@ class TestPageChangeTemplateView(BaseViewsCase):
 class TestPageBlockAddView(BaseViewsCase):
     def setUp(self):
         super(TestPageBlockAddView, self).setUp()
-        self.page_block_add_view_url = reverse(
+        self.page_block_add_view_url = '{}?column=main_content'.format(reverse(
             'block_admin:%s_%s_add' % (HTML._meta.app_label, HTML._meta.model_name),
             kwargs={
                 'version_id': self.page_version.id,
             }
-        )
+        ))
 
     def test_permissions(self):
         # Permission denied as user doesn't have permissions

--- a/glitter/tests/test_admin.py
+++ b/glitter/tests/test_admin.py
@@ -13,6 +13,7 @@ from django.http import HttpRequest
 from django.test import TestCase, Client
 from django.test import override_settings, modify_settings
 from django.test.client import RequestFactory
+from django.utils.http import urlencode
 
 from glitter.forms import MoveBlockForm
 from glitter.blocks.html.models import HTML
@@ -368,19 +369,26 @@ class TestPageBlockAddView(BaseViewsCase):
         response = self.editor_client.get(self.page_block_add_view_url)
         self.assertEqual(response.status_code, 200)
 
-    def test_post(self):
+    def test_add_block(self):
         response = self.editor_client.post(self.page_block_add_view_url, {
-            'column': 'main_content',
-            'block_type': u'glitter_html_block.HTML',
-            'top': 'true',
+            'content': '<p>Test</p>',
         })
         self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'admin/glitter/update_column.html')
 
-        response = self.editor_client.post(self.page_block_add_view_url, {
-            'column': 'main_content',
-            'block_type': u'glitter_html_block.HTML',
+    def test_add_block_top(self):
+        response = self.editor_client.post(self.page_block_add_view_url + '&top=true', {
+            'content': '<p>Test</p>',
         })
         self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'admin/glitter/update_column.html')
+
+    def test_add_continue(self):
+        response = self.editor_client.post(self.page_block_add_view_url, {
+            'content': '<p>Test</p>',
+            '_continue': '',
+        })
+        self.assertEqual(response.status_code, 302)
 
     def test_page_version(self):
         """ Check page version. """


### PR DESCRIPTION
Instead of creating a block with default values, we now immediately load a popup and force a user to enter the blocks content before saving it.

I've moved the add view from the block admin to the block itself. Sadly as it's the Django admin once again - being unable to set attributes is annoying/limiting. I've added in a bit of a hack to get this done - is this acceptable?

Will add a few tests if we're happy with this approach. After that I'll be doing another pull request which will delete empty blocks.

Closes #26, closes #73.